### PR TITLE
Update montador.h

### DIFF
--- a/program/montador.h
+++ b/program/montador.h
@@ -35,7 +35,7 @@ typedef struct Tipo_I {
 
 typedef struct TipoS {
     //Estrutura da instrução;
-    char* nome_Instrucao[5];
+    char nome_Instrucao[5];
     int immediate_7; // 31 - 25
     int Rs2_5; // 24 - 20
     int Rs1_5; // 19 - 15


### PR DESCRIPTION
Strings que possuem tamanhos pre-determinados não devem ser apresentadas com ponteiros, removido  ponteiro em nome da instrução de S